### PR TITLE
Add JsonParent cli option.

### DIFF
--- a/src/7factor.io/_unittests/args_test.go
+++ b/src/7factor.io/_unittests/args_test.go
@@ -12,6 +12,7 @@ var mockInfileArg = []string{"cmd", "-i", "valid_path.env"}
 var mockWithOutput = []string{"cmd", "-i", "valid_path.env", "-o", "output.json"}
 var mockWithVariable = []string{"cmd", "-i", "valid_path.env", "-v", "A=B"}
 var mockWithMultipleVariables = []string{"cmd", "-i", "valid_path.env", "-v", "C=D", "-v", "E=F"}
+var mockWithJsonParent = []string{"cmd", "-i", "valid_path.env", "-p", "env"}
 
 var _ = Describe("The argument parser", func() {
 	Context("When not passed `INFILE` arg", func() {
@@ -36,6 +37,13 @@ var _ = Describe("The argument parser", func() {
 			Expect(err).To(BeNil())
 			Expect(config.OutFile).To(Equal("stdout"))
 		})
+
+		It("Does not set the json parent key.", func() {
+			os.Args = mockInfileArg
+			config, err := args.GetArguments()
+			Expect(err).To(BeNil())
+			Expect(config.JsonParent).To(BeNil())
+		})
 	})
 
 	Context("When called with the output flag and a specified output file", func() {
@@ -49,7 +57,7 @@ var _ = Describe("The argument parser", func() {
 
 	Context("When called with the variable flag and a specified variable", func() {
 		It("Returns then appropriate `ArgConfig` struct with the expected variable", func() {
-			os. Args = mockWithVariable
+			os.Args = mockWithVariable
 			config, err := args.GetArguments()
 			Expect(err).To(BeNil())
 			Expect(config.Variables).To(Equal([]string{"A=B"}))
@@ -62,6 +70,15 @@ var _ = Describe("The argument parser", func() {
 			config, err := args.GetArguments()
 			Expect(err).To(BeNil())
 			Expect(config.Variables).To(Equal([]string{"C=D", "E=F"}))
+		})
+	})
+
+	Context("When called with an infile and a json parent key", func() {
+		It("Sets the json parent key.", func() {
+			os.Args = mockWithJsonParent
+			config, err := args.GetArguments()
+			Expect(err).To(BeNil())
+			Expect(*config.JsonParent).To(Equal("env"))
 		})
 	})
 })

--- a/src/7factor.io/_unittests/ecs_test.go
+++ b/src/7factor.io/_unittests/ecs_test.go
@@ -2,12 +2,16 @@ package _unittests
 
 import (
 	"7factor.io/converter"
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 // Constants for testing.
 const EmptyEnvironmentArray = `[]`
+const EmptyEnvironmentObject = `{}`
+const DefaultParentKey = `env_vars`
+const EmptyEnvironmentArrayParentKey = `{"%s":[]}`
 const SingleLineSingleInput = `A=B`
 const EmptyValueInput = `A=`
 const MultiEmptyValueInput = `
@@ -221,6 +225,30 @@ var _ = Describe("The ECS converter", func() {
 			converted, err := converter.ConvertInputToJson([]string{CrazyInput})
 			Expect(err).To(BeNil())
 			Expect(converted).To(Equal(`[{"name":"A","value":"1"},{"name":"B","value":"2"},{"name":"C","value":"test string"},{"name":"D","value":"another test string"},{"name":"E","value":"1"},{"name":"F","value":"2"},{"name":"G","value":"another test string"},{"name":"H","value":"test string"}]`))
+		})
+	})
+
+	Context("When passed a parent key and a blank file", func() {
+		It("Returns an empty JSON blob", func() {
+			converted, err := converter.ConvertInputToJsonObject([]string{}, DefaultParentKey)
+			Expect(err).ToNot(BeNil())
+			Expect(converted).To(Equal(fmt.Sprintf(EmptyEnvironmentArrayParentKey, DefaultParentKey)))
+		})
+	})
+
+	Context("When passed a single line file without comments and a blank parent key", func() {
+		It("Returns an empty JSON blob", func() {
+			converted, err := converter.ConvertInputToJsonObject([]string{}, "")
+			Expect(err).ToNot(BeNil())
+			Expect(converted).To(Equal(EmptyEnvironmentObject))
+		})
+	})
+
+	Context("When passed a parent key and a single line file without comments", func() {
+		It("Returns the expected JSON blob", func() {
+			converted, err := converter.ConvertInputToJsonObject([]string{SingleLineSingleInput}, DefaultParentKey)
+			Expect(err).To(BeNil())
+			Expect(converted).To(Equal(`{"env_vars":[{"name":"A","value":"B"}]}`))
 		})
 	})
 })

--- a/src/7factor.io/args/args.go
+++ b/src/7factor.io/args/args.go
@@ -5,13 +5,14 @@ import (
 )
 
 type ArgConfig struct {
-	InFile    string
-	OutFile   string
-	Variables []string
+	InFile     string
+	OutFile    string
+	JsonParent *string
+	Variables  []string
 }
 
 func GetArguments() (ArgConfig, error) {
 	_, err := flags.Parse(&opt)
 
-	return ArgConfig{opt.Infile, opt.Outfile, opt.Variables}, err
+	return ArgConfig{opt.Infile, opt.Outfile, opt.JsonParent, opt.Variables}, err
 }

--- a/src/7factor.io/args/args_models.go
+++ b/src/7factor.io/args/args_models.go
@@ -3,7 +3,8 @@ package args
 // Place your Args models here and call them in args.go
 // Include your cli short and long flags, default value for arg if needed, and a usage string to show up in --help calls.
 var opt struct {
-	Infile    string   `short:"i" long:"infile" description:"The infile to parse." required:"true"`
-	Outfile   string   `short:"o" long:"outfile" description:"The outfile to write to." default:"stdout" required:"false"`
-	Variables []string `short:"v" long:"variable" description:"Optional variable to pass ie A=B." required:"false"`
+	Infile     string   `short:"i" long:"infile" description:"The infile to parse." required:"true"`
+	Outfile    string   `short:"o" long:"outfile" description:"The outfile to write to." default:"stdout" required:"false"`
+	JsonParent *string  `short:"p" long:"parent" description:"If defined, the output array will be wrapped in a parent json object and associated with this flag's value as the key." required:"false"`
+	Variables  []string `short:"v" long:"variable" description:"Optional variable to pass ie A=B." required:"false"`
 }

--- a/src/7factor.io/converter/common.go
+++ b/src/7factor.io/converter/common.go
@@ -16,7 +16,12 @@ func ReadAndConvert(config ArgConfig) (string, error) {
 
 	withExtraVars := append(contents, config.Variables...)
 
-	transformedContents, err := ConvertInputToJson(withExtraVars)
+	var transformedContents string
+	if config.JsonParent != nil {
+		transformedContents, err = ConvertInputToJsonObject(withExtraVars, *config.JsonParent)
+	} else {
+		transformedContents, err = ConvertInputToJson(withExtraVars)
+	}
 	if err != nil {
 		return "", fmt.Errorf("caught error while attempting to transform contents: %s\n", err)
 	}


### PR DESCRIPTION
This option allows wrapping the env vars array in a parent object. What this means is that we can pass the output file into `var_files` instead of `vars` for terraform `put` steps in a pipeline and end up passing non-encoded variables to terraform. Further, this switch to `var_files` allows us to use the original `ljfranklin/terraform-resource` instead of our own which is frequently out of date.

Usage wise, the argument passed in with the `-p` flag is the name of the terraform variable. Example `-p env_vars` would go into a terraform variable that looks like 
```hcl
variable "env_vars" {
  type = list(object({
    name  = string
    value = any
  }))
}
```
And this would be used in the ecs task module's container definition (assuming you're using `jsonencode` and not heredocs) like
```hcl
  container_definition = jsonencode([
    {
      # ...
      environment      = var.env_vars
    }
  ])
```